### PR TITLE
Make the gdbm subproject build on GCC 10

### DIFF
--- a/vendor/gdbm/src/parseopt.c
+++ b/vendor/gdbm/src/parseopt.c
@@ -252,8 +252,8 @@ print_option_descr (const char *descr, size_t lmargin, size_t rmargin)
 }
 
 char *parseopt_program_name;
-char *parseopt_program_doc;
-char *parseopt_program_args;
+extern char *parseopt_program_doc;
+extern char *parseopt_program_args;
 const char *program_bug_address = "<" PACKAGE_BUGREPORT ">";
 void (*parseopt_help_hook) (FILE *stream);
 


### PR DESCRIPTION
Two variables were not declared as extern. This works until GCC 9, due to the common model, but his has been disabled on GCC 10, which therefore requires changes.

See https://bugs.gentoo.org/705898.